### PR TITLE
Add RSS to README and Podcast Microsite Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The Untold Stories of Open Source
 
-[![rss](https://github.com/aleen42/badges/blob/master/src/rss.svg?raw=true)](https://feeds.captivate.fm/untold-stories-of-open-source/)
-
 <img src="docs/images/logo-400-400.png" width="230" height="230" />
+
+[![rss](https://github.com/aleen42/badges/blob/master/src/rss.svg?raw=true)](https://feeds.captivate.fm/untold-stories-of-open-source/)
 
 Open Source is embedded in every software application you touch today.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Untold Stories of Open Source
 
+[![rss](https://github.com/aleen42/badges/blob/master/src/rss.svg?raw=true)](https://feeds.captivate.fm/untold-stories-of-open-source/)
+
 <img src="docs/images/logo-400-400.png" width="230" height="230" />
 
 Open Source is embedded in every software application you touch today.
@@ -22,7 +24,7 @@ Listen to the latest episodes from The Linux Foundation ["The Untold Stories of 
 
 ## Listen in your Browser
 
-Listen to Linux Foundation podcasts in your browser by visiting [The Untold Stories of Open Source](https://podcast.linuxfoundation.org/) microsite. It is also available on Spotify, Apple Podcasts, Amazon Podcast, and Google Podcast, and dozens of other podcast platforms. 
+Listen to Linux Foundation podcasts in your browser by visiting [The Untold Stories of Open Source](https://podcast.linuxfoundation.org/) microsite. It is also available on Spotify, Apple Podcasts, Amazon Podcast, and Google Podcast, and dozens of other podcast platforms.
 
 ## What the project does
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,11 +40,8 @@ module.exports = {
         {to: 'docs/podcasts-intro', label: 'Introduction', position: 'right'},
         {to: 'docs/podcasts/new-model-training', label: 'Podcasts', position: 'right'},
         {to: 'docs/templates/podcast-template', label: 'Add New Podcast', position: 'right'},
-        {
-          href: 'https://github.com/linuxfoundation/lf-podcast',
-          label: 'GitHub',
-          position: 'right',
-        }
+        {href: 'https://feeds.captivate.fm/untold-stories-of-open-source/', label: 'RSS', position: 'right'},        
+        {href: 'https://github.com/linuxfoundation/lf-podcast', label: 'GitHub', position: 'right'}
       ],
     },
     footer: {


### PR DESCRIPTION
## Description
This PR closes #17 by adding an `rss` badge to **The Untold Stories of Open Source** [README.md](https://github.com/linuxfoundation/lf-podcast/blob/main/README.md) and the [podcast microsite](https://podcast.linuxfoundation.org/) header. The RSS link is https://feeds.captivate.fm/untold-stories-of-open-source/

## RSS Badge
```
[![rss](https://github.com/aleen42/badges/blob/master/src/rss.svg?raw=true)](https://feeds.captivate.fm/untold-stories-of-open-source/)
```
[![rss](https://github.com/aleen42/badges/blob/master/src/rss.svg?raw=true)](https://feeds.captivate.fm/untold-stories-of-open-source/)

[MIT](https://wiki.aleen42.com/MIT.html) © @aleen42

## RSS Header Link
The following RSS link was added to the podcast microsite header so it's persistent throughout the entire microsite.

### Config File
`./website/docusaurus.config.js`

### Config Setting
```
{href: 'https://feeds.captivate.fm/untold-stories-of-open-source/', label: 'RSS', position: 'right'},        
{href: 'https://github.com/linuxfoundation/lf-podcast', label: 'GitHub', position: 'right'}
```
