### PR TITLE
Clarified statement in README.md line 51 to improve readability (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Linux Foundation Podcast Project is a public podcast. Each week, the podcast
 
 ## Why the project is useful
 
-The podcast is used to inform the Linux and Open Source communities as to the current state in development of open source initiatives and Linux Foundation Projects. It is vendor neutral, with no interviews of commercial product vendors or sales teams.
+The podcast aims to inform the Linux and Open Source communities about the current state of open-source initiatives and Linux Foundation projects. It is vendor-neutral, with no interviews of commercial product vendors or sales teams.
 
 ## How users can get started with the project
 


### PR DESCRIPTION
This pull request addresses [issue #44](https://github.com/linuxfoundation/lf-podcast/issues/44) by improving the clarity and readability of the statement on line 51 in the README.md file.

Changes Made
Revised wording to make the purpose of the podcast clearer and more concise.
Enhanced readability and flow by simplifying phrases and adding a hyphen in "vendor-neutral."
Before:

The podcast is used to inform the Linux and Open Source communities as to the current state in development of open source initiatives and Linux Foundation Projects. It is vendor neutral, with no interviews of commercial product vendors or sales teams.

After:

The podcast aims to inform the Linux and Open Source communities about the current state of open-source initiatives and Linux Foundation projects. It is vendor-neutral, with no interviews of commercial product vendors or sales teams.

Reason for Change
The original sentence had minor readability issues, which this edit aims to address.