### PR TITLE
Fix redundancy in video display on "Is the finance industry using open source?" page

### DIFF
--- a/docs/podcasts/finance-industry.mdx
+++ b/docs/podcasts/finance-industry.mdx
@@ -11,7 +11,7 @@ import { podcasts } from "@site/src/components/podcasts";
 
 ## Gabriele Columbro Spotlight
 
-https://user-images.githubusercontent.com/66965127/189157525-c0500769-2f4a-479a-9c45-6cad9724f772.mp4
+
 
 <ReactPlayer
   url="https://user-images.githubusercontent.com/66965127/189157525-c0500769-2f4a-479a-9c45-6cad9724f772.mp4"


### PR DESCRIPTION
### Summary:
This PR addresses the redundancy in the "Gabriele Columbro Spotlight" section of the page. The issue arose from displaying both a direct video link and an embedded video player for the same content. 

### Changes:
- Removed the direct link to the video, leaving only the embedded ReactPlayer to prevent confusion and improve the user experience.

### Impact:
- The page will now only display the embedded video player, streamlining the presentation and avoiding any redundancy.
